### PR TITLE
changed u_mod_healthy -> u_health()

### DIFF
--- a/bionic_eocs.json
+++ b/bionic_eocs.json
@@ -177,7 +177,7 @@
     },
     "false_effect": [
       { "math": [ "u_val('power')", "-=", "energy('10 kJ')" ] },
-      { "u_mod_healthy": -5, "cap": -250 },
+      { "math": [ "u_health()", "-=", "5" ] },
       { "run_eocs": "mod_reserves", "variables": { "reserve_id": "reserve_tear_gas", "operation": "+=", "modifier": "1" } }
     ]
   },
@@ -194,7 +194,7 @@
     },
     "false_effect": [
       { "math": [ "u_val('power')", "-=", "energy('10 kJ')" ] },
-      { "u_mod_healthy": -5, "cap": -250 },
+      { "math": [ "u_health()", "-=", "5" ] },
       { "run_eocs": "mod_reserves", "variables": { "reserve_id": "reserve_fungicide", "operation": "+=", "modifier": "1" } }
     ]
   },
@@ -211,7 +211,7 @@
     },
     "false_effect": [
       { "math": [ "u_val('power')", "-=", "energy('10 kJ')" ] },
-      { "u_mod_healthy": -5, "cap": -250 },
+      { "math": [ "u_health()", "-=", "5" ] },
       { "run_eocs": "mod_reserves", "variables": { "reserve_id": "reserve_insecticide", "operation": "+=", "modifier": "1" } }
     ]
   },


### PR DESCRIPTION
## Description
Changed uses of `u_mod_healthy` to use the function `u_health()` instead.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
Launched a world on the latest version and it worked.

## Notes
Related PR: https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1133