### PR TITLE
Fix u_lose_effect Throwing Error

### DIFF
--- a/bionic_eocs.json
+++ b/bionic_eocs.json
@@ -277,7 +277,7 @@
           "duration": "PERMANENT",
           "intensity": { "u_val": "cur_intensity" }
         },
-        "else": { "u_lose_effect": { "context_val": "reserve_id" } }
+        "else": { "u_lose_effect": [ { "context_val": "reserve_id" } ] }
       }
     ]
   },


### PR DESCRIPTION
## Description
`u_lose_effect` was having problems dealing with a dynamic object not being inside an array so I fixed that.

## PR Type
- [x] Bug Fix
- [ ] Code Refactor
- [ ] Doc Changes
- [ ] New Asset(s)
- [ ] New Feature(s)

## PR Size
- [x] One-line
- [ ] Small
- [ ] Medium
- [ ] Large

## Testing
Loaded a test world and no error occurred on start up.

## Notes
Original error:
```
 DEBUG : (json-error)
Json error: file C:/Users/finnl/OneDrive/Desktop/CTLG_launcher/tlg/userdata/mods/BionicsExpanded-CTLG/bionic_eocs.json, at line 280, character 35:
<color_white><color_cyan>Unread data.  Invalid or misplaced field name "u_lose_effect" in JSON data</color>

          "intensity": { "u_val": "cur_intensity" }
        },
<color_light_red>        "else": { "u_lose_effect": { "context_val": "reserve_id" } }
</color>
                                 <color_cyan>▲▲▲</color>
      }
    ]
</color>


 REPORTING FUNCTION : error_skipped_members
 C++ SOURCE FILE    : D:\a\Cataclysm-TLG\Cataclysm-TLG\src\flexbuffer_json.cpp
 LINE               : 347
 VERSION            : 2025-09-10-2044
```